### PR TITLE
Solution for augment a node in module from submodule

### DIFF
--- a/test/lux/tree/augment-test/mod1.yang
+++ b/test/lux/tree/augment-test/mod1.yang
@@ -1,0 +1,6 @@
+module mod1 {
+  namespace "http://hkt.com/ns/yang/mod1";
+  prefix m1;
+
+  container mod1-con;
+}

--- a/test/lux/tree/augment-test/mod2-sub.yang
+++ b/test/lux/tree/augment-test/mod2-sub.yang
@@ -1,0 +1,23 @@
+submodule mod2-sub {
+  belongs-to mod2 {
+    prefix m2;
+  }
+
+  import mod1 {
+    prefix m1;
+  }
+
+  // leafref referring to a leaf defined in augment statement of the main module
+  leaf mod2-sub-leaf1 {
+    type leafref {
+      path "/m1:mod1-con/mod2-con2/mod2-leaf1";
+    }
+  }
+
+  // Augment container in main module from submodule
+  augment "/mod2-con3" {
+    leaf mod2-sub-leaf2 {
+      type string;
+    }
+  }
+}

--- a/test/lux/tree/augment-test/mod2.yang
+++ b/test/lux/tree/augment-test/mod2.yang
@@ -1,0 +1,28 @@
+module mod2 {
+  namespace "http://hkt.com/ns/yang/mod2";
+  prefix m2;
+
+  include mod2-sub;
+
+  import mod1 {
+    prefix m1;
+  }
+
+  augment "/m1:mod1-con" {
+    container mod2-con1;
+  }
+
+  augment "/m1:mod1-con" {
+    container mod2-con2 {
+      leaf mod2-leaf1 {
+        type string;
+      }
+    }
+  }
+
+  container mod2-con3 {
+    leaf mod2-leaf2 {
+      type string;
+    }
+  }
+}

--- a/test/lux/tree/augment-test/mod3-sub1.yang
+++ b/test/lux/tree/augment-test/mod3-sub1.yang
@@ -1,0 +1,36 @@
+submodule mod3-sub1 {
+  belongs-to mod3 {
+    prefix m3;
+  }
+
+  import mod1 {
+    prefix m1;
+  }
+
+  import mod2 {
+    prefix m2;
+  }
+
+  // leafref referring to a leaf defined in augment statement of the main module
+  leaf mod3-sub1-leaf1 {
+    type leafref {
+      path "/m1:mod1-con/m2:mod2-con1/mod3-g-con/mod3-g-leaf";
+    }
+  }
+
+  // leafref referring to a leaf defined in an augment statement of another
+  // submodule of the same main module.
+  leaf mod3-sub1-leaf2 {
+    type leafref {
+      path "/m1:mod1-con/m2:mod2-con1/mod3-sub2-con1/mod3-sub2-leaf1";
+    }
+  }
+
+  // leafref referring to a leaf defined in an another submodule
+  // of the same main module.
+  leaf mod3-sub1-leaf3 {
+    type leafref {
+      path "/mod3-sub2-leaf2";
+    }
+  }
+}

--- a/test/lux/tree/augment-test/mod3-sub2.yang
+++ b/test/lux/tree/augment-test/mod3-sub2.yang
@@ -1,0 +1,29 @@
+submodule mod3-sub2 {
+  belongs-to mod3 {
+    prefix m3;
+  }
+
+  import mod1 {
+    prefix m1;
+  }
+
+  import mod2 {
+    prefix m2;
+  }
+
+  augment "/m1:mod1-con/m2:mod2-con1" {
+    container mod3-sub2-con1 {
+      leaf mod3-sub2-leaf1 {
+        type string;
+      }
+    }
+  }
+
+  // leafref referring to a leaf defined in an another submodule
+  // of the difference main module.
+  leaf mod3-sub2-leaf2 {
+    type leafref {
+      path "/m2:mod2-sub-leaf1";
+    }
+  }
+}

--- a/test/lux/tree/augment-test/mod3.yang
+++ b/test/lux/tree/augment-test/mod3.yang
@@ -1,0 +1,28 @@
+module mod3 {
+  namespace "http://hkt.com/ns/yang/mod3";
+  prefix m3;
+
+  include mod3-sub1;
+  include mod3-sub2;
+
+  import mod1 {
+    prefix m1;
+  }
+
+  import mod2 {
+    prefix m2;
+  }
+
+  grouping mod3-group {
+    container mod3-g-con {
+      leaf mod3-g-leaf {
+        type string;
+      }
+    }
+  }
+
+  augment "/m1:mod1-con/m2:mod2-con1" {
+    uses mod3-group;
+  }
+
+}

--- a/test/lux/tree/augment-test/submodule-alone.yang
+++ b/test/lux/tree/augment-test/submodule-alone.yang
@@ -1,0 +1,18 @@
+submodule submodule-alone {
+  belongs-to non-existent-module {
+    prefix nem;
+  }
+  leaf alex {
+    type string;
+  }
+  leaf bob {
+    type leafref {
+      path "../alex";
+    }
+  }
+  leaf carol {
+    type leafref {
+      path "/nem:alex";
+    }
+  }
+}

--- a/test/lux/tree/augment_test.lux
+++ b/test/lux/tree/augment_test.lux
@@ -1,0 +1,81 @@
+[doc text example:structure]
+
+[shell yanger]
+    !cd ./augment-test
+    !yanger -f tree mod1.yang
+    """???
+    module: mod1
+      +--rw mod1-con
+    SH-PROMPT
+    """
+
+    !yanger -f tree mod2.yang
+    """???
+    module: mod2
+      +--rw mod2-sub-leaf1?   -> /m1:mod1-con/mod2-con2/mod2-leaf1
+      +--rw mod2-con3
+         +--rw mod2-leaf2?       string
+         +---- mod2-sub-leaf2?   string
+
+      augment /m1:mod1-con:
+        +--rw mod2-con1
+      augment /m1:mod1-con:
+        +--rw mod2-con2
+           +--rw mod2-leaf1?   string
+    SH-PROMPT
+    """
+
+    !yanger -f tree mod2-sub.yang
+    """???
+    submodule: mod2-sub (belongs-to mod2)
+      +--rw mod2-sub-leaf1?   -> /m1:mod1-con/mod2-con2/mod2-leaf1
+    SH-PROMPT
+    """
+
+    !yanger -f tree mod3.yang
+    """???
+    module: mod3
+      +--rw mod3-sub1-leaf1?   -> /m1:mod1-con/m2:mod2-con1/mod3-g-con/mod3-g-leaf
+      +--rw mod3-sub1-leaf2?   -> /m1:mod1-con/m2:mod2-con1/mod3-sub2-con1/mod3-sub2-leaf1
+      +--rw mod3-sub1-leaf3?   -> /mod3-sub2-leaf2
+      +--rw mod3-sub2-leaf2?   -> /m2:mod2-sub-leaf1
+
+      augment /m1:mod1-con/m2:mod2-con1:
+        +--rw mod3-sub2-con1
+           +--rw mod3-sub2-leaf1?   string
+      augment /m1:mod1-con/m2:mod2-con1:
+        +--rw mod3-g-con
+           +--rw mod3-g-leaf?   string
+    SH-PROMPT
+    """
+
+    !yanger -f tree mod3-sub1.yang
+    """???
+    submodule: mod3-sub1 (belongs-to mod3)
+      +--rw mod3-sub1-leaf1?   -> /m1:mod1-con/m2:mod2-con1/mod3-g-con/mod3-g-leaf
+      +--rw mod3-sub1-leaf2?   -> /m1:mod1-con/m2:mod2-con1/mod3-sub2-con1/mod3-sub2-leaf1
+      +--rw mod3-sub1-leaf3?   -> /mod3-sub2-leaf2
+    SH-PROMPT
+    """
+
+    !yanger -f tree mod3-sub2.yang
+    """???
+    submodule: mod3-sub2 (belongs-to mod3)
+      +--rw mod3-sub2-leaf2?   -> /m2:mod2-sub-leaf1
+
+      augment /m1:mod1-con/m2:mod2-con1:
+        +--rw mod3-sub2-con1
+           +--rw mod3-sub2-leaf1?   string
+    SH-PROMPT
+    """
+
+    !yanger -f tree submodule-alone.yang
+    """???
+    submodule: submodule-alone (belongs-to non-existent-module)
+      +--rw alex?    string
+      +--rw bob?     -> ../alex
+      +--rw carol?   -> /alex
+    SH-PROMPT
+    """
+
+

--- a/test/lux/tree/example.lux
+++ b/test/lux/tree/example.lux
@@ -1,6 +1,7 @@
 [doc text example:structure]
 
 [shell yanger]
+    !cd ./path-referencing
     !yanger -f tree example.yang
     """???
     module: example


### PR DESCRIPTION
Yanger will read the submodule first before reading the module.
If the submodule augment a node from the module, the result will be 'node ~s not found'. The submodule will create a tmp_augment node. However, it was never got check again when reading the module. 
This fix includes checking for the tmp_augment node when reading the module.